### PR TITLE
Continuous deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+script:
+- PATH=$HOME/.local/bin:$PATH script/travis-deploy.sh
+env:
+  secure: I561JmbFzYrW1UsgcZb15Mw8WK3F/wEToNVcxhFXG+ps3cKX9ZtDarkFFnRkg0z7vJZcekyOEOTxquOVMbaNZffcgidT87K/FkRu205yrp8c4NUWcyDWNT+zpntQefEjsAujpm5q7pjWuThyXkj7HkdE40TAASt9QfcEM74Gwxk=

--- a/script/travis-deploy.sh
+++ b/script/travis-deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Deploy to staging (but not on PRs)
+
+set -e
+
+if [ "$TRAVIS_BRANCH" == "master" ] &&
+   [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then
+   gem install -N travis
+   travis restart -t "$TRAVIS_TOKEN" \
+                  -r aptible/www.aptible.com \
+                  --skip-completion-check
+fi


### PR DESCRIPTION
Copied from aptible-pages. Not sure how long this token will work... Process for creating and storing Travis CI token, given 

\#PosterityOctopus

Grab Travis token:

```
curl -H 'Content-Type: application/json' -d '{"github_token":"GITHUB_TOKEN"}' https://api.travis-ci.org/auth/github
```

Store Travis token:

```
travis encrypt -r aptible/aptible-legal --add env TRAVIS_TOKEN=...
```